### PR TITLE
Add print CSS for PDF export - Closes #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ A python script for extracting WhatsApp conversations from the app's SQLite data
 4. Open then generated HTML page (configured via `html_output_path`) with a web browser. To view media files, simply 
    place WhatsApp's `Media` directory to the same directory as the HTML page.
 
+In order to export only certain chats (or to include further filtering requirements), the SQL queries in `main.py` 
+can be modified directly.
+
+```SQL
+# New database format: Modify query_messages_from_table_message to filter for the chat with phone number 12345678
+WHERE cv.raw_string_jid =:key_remote_jid and cv.raw_string_jid = '12345678@s.whatsapp.net'
+
+# Old database format: Modify query_messages_from_table_messages to filter for the chat with phone number 12345678
+WHERE key_remote_jid =:key_remote_jid and key_remote_jid = '12345678@s.whatsapp.net'
+```  
+
 ## Retrieving WhatsApp Databases
 
 For retrieving the WhatsApp database files from an Android device there are several options. Two of them are described in this section.

--- a/whatsapp-exporter/exporter.py
+++ b/whatsapp-exporter/exporter.py
@@ -20,9 +20,10 @@ def chats_to_html(chats: list, filepath: str):
             continue
 
         # Add the chat contents to the HTML
-        t = Template("""<div class="chat" data-chatid="$chat_id">$messages</div>""")
+        t = Template("""<div class="chat" data-chatid="$chat_id" data-chat-title="$title">$messages</div>""")
         chat_contents += t.substitute(
             chat_id=_esc(chat.key_remote_jid),
+            title=_esc(chat.title),
             messages="".join([_message_to_html(m) for m in chat.messages])
         )
 

--- a/whatsapp-exporter/resources/styles.css
+++ b/whatsapp-exporter/resources/styles.css
@@ -124,3 +124,31 @@ header h1 {
     width: auto;
     max-height: 400px;
 }
+
+/* Print styles */
+@media print {
+    main {
+        width: 100%;
+        box-shadow: none;
+        display: block;
+        border: none;
+    }
+
+    div.chat {
+        overflow: visible;
+        display: flex;
+    }
+
+    div.chat::before {
+        content: attr(data-chat-title) ' (' attr(data-chatid) ')';
+        font-size: 1.2rem;
+    }
+
+    .chats-list {
+        display: none;
+    }
+
+    .message {
+        border: 1px solid #D8D8D8;
+    }
+}


### PR DESCRIPTION
This PR adds additional styles so that the generated HTML page can be printed, e.g. to a PDF file.